### PR TITLE
Make docker hub requests authenticated

### DIFF
--- a/update-docker-tags.go
+++ b/update-docker-tags.go
@@ -34,7 +34,7 @@ const (
 	helpEnforce    = "override given docker image to enforce a semver constraint (repeatable)"
 	helpUpdate     = "update target docker images using the already set tags (repeatable)"
 	helpUsername   = "Docker Hub username (required)"
-	helpPassword   = "Docker Hub password (required)"
+	helpPassword   = "Docker Hub password or access token, https://docs.docker.com/docker-hub/access-tokens/ (required)"
 )
 
 func main() {

--- a/update-docker-tags.go
+++ b/update-docker-tags.go
@@ -87,11 +87,8 @@ Examples:
 	if err != nil {
 		log.Fatalf("failed to parse raw enforce, err: %s", err)
 	}
-	if dockerUsername == "" {
-		log.Fatal("--username is required")
-	}
-	if dockerPassword == "" {
-		log.Fatal("--password is required")
+	if dockerUsername == "" && dockerPassword == "" {
+		log.Println("no docker username and password provided, please note you may get rate-limited")
 	}
 
 	paths := flag.Args()
@@ -277,7 +274,9 @@ func (r *repository) fetchImageDigest(tag string) (string, error) {
 //
 func fetchAuthToken(repositoryName string) (string, error) {
 	req, err := http.NewRequest("GET", fmt.Sprintf("https://auth.docker.io/token?service=registry.docker.io&scope=repository:%s:pull", repositoryName), nil)
-	req.SetBasicAuth(dockerUsername, dockerPassword)
+	if dockerUsername != "" && dockerPassword != "" {
+		req.SetBasicAuth(dockerUsername, dockerPassword)
+	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", err

--- a/update-docker-tags.go
+++ b/update-docker-tags.go
@@ -25,12 +25,16 @@ var (
 	constraintArgs rawConstraints
 	enforceArgs    rawConstraints
 	updateArgs     stringArray
+	dockerUsername string
+	dockerPassword string
 )
 
 const (
 	helpConstraint = "perform semver update on given docker image to satisfy semver constraint (repeatable)"
 	helpEnforce    = "override given docker image to enforce a semver constraint (repeatable)"
 	helpUpdate     = "update target docker images using the already set tags (repeatable)"
+	helpUsername   = "Docker Hub username (required)"
+	helpPassword   = "Docker Hub password (required)"
 )
 
 func main() {
@@ -44,6 +48,8 @@ Options:
 	--constraint  %s 
 	--enforce     %s
 	--update      %s
+	--username    %s
+	--password    %s
 
 Examples:
 
@@ -62,12 +68,14 @@ Examples:
 	Override all tags in the given files and folders to enforce a constraint:
 
 	$ update-docker-tags --enforce=sourcegraph/frontend=~3.19
-`, helpConstraint, helpEnforce, helpUpdate)
+`, helpConstraint, helpEnforce, helpUpdate, helpUsername, helpPassword)
 		os.Exit(2)
 	}
 	flag.Var(&constraintArgs, "constraint", helpConstraint)
 	flag.Var(&enforceArgs, "enforce", helpEnforce)
 	flag.Var(&updateArgs, "update", helpEnforce)
+	flag.StringVar(&dockerUsername, "username", os.Getenv("CR_USERNAME"), helpUsername)
+	flag.StringVar(&dockerPassword, "password", os.Getenv("CR_PASSWORD"), helpPassword)
 
 	flag.Parse()
 
@@ -78,6 +86,12 @@ Examples:
 	parsedEnforce, err := enforceArgs.parse()
 	if err != nil {
 		log.Fatalf("failed to parse raw enforce, err: %s", err)
+	}
+	if dockerUsername == "" {
+		log.Fatal("--username is required")
+	}
+	if dockerPassword == "" {
+		log.Fatal("--password is required")
 	}
 
 	paths := flag.Args()
@@ -257,10 +271,14 @@ func (r *repository) fetchImageDigest(tag string) (string, error) {
 
 // Effectively the same as:
 //
-// 	$ export token=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:sourcegraph/server:pull" | jq -r .token)
+// 	$ export token=$(curl --user 'user:password' -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:sourcegraph/server:pull" | jq -r .token)
+//
+// Learn more ➡️ https://docs.docker.com/docker-hub/download-rate-limit/#how-can-i-check-my-current-rate
 //
 func fetchAuthToken(repositoryName string) (string, error) {
-	resp, err := http.Get(fmt.Sprintf("https://auth.docker.io/token?service=registry.docker.io&scope=repository:%s:pull", repositoryName))
+	req, err := http.NewRequest("GET", fmt.Sprintf("https://auth.docker.io/token?service=registry.docker.io&scope=repository:%s:pull", repositoryName), nil)
+	req.SetBasicAuth(dockerUsername, dockerPassword)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", err
 	}

--- a/update-docker-tags.go
+++ b/update-docker-tags.go
@@ -90,6 +90,9 @@ Examples:
 	if dockerUsername == "" && dockerPassword == "" {
 		log.Println("no docker username and password provided, please note you may get rate-limited")
 	}
+	if (dockerUsername == "" && dockerPassword != "") || (dockerUsername != "" && dockerPassword == "") {
+		log.Fatalf("both docker username and password must be provided at the same time")
+	}
 
 	paths := flag.Args()
 	if len(paths) == 0 {


### PR DESCRIPTION
Fix https://github.com/sourcegraph/sourcegraph/issues/30758

workaround for the docker hub rate limit

The solution is pretty straight forward, just add a basic auth header when invoking `auth.docker.io`. When an authenticated token is used for subsequent requests, there shouldn't be any `ratelimit-*` headers from the response

not authenticated
```
HTTP/1.1 200 OK
content-length: 2782
content-type: application/vnd.docker.distribution.manifest.v1+prettyjws
docker-content-digest: sha256:767a3815c34823b355bed31760d5fa3daca0aec2ce15b217c9cd83229e0e2020
docker-distribution-api-version: registry/2.0
etag: "sha256:767a3815c34823b355bed31760d5fa3daca0aec2ce15b217c9cd83229e0e2020"
date: Mon, 07 Feb 2022 21:56:51 GMT
strict-transport-security: max-age=31536000
ratelimit-limit: 100;w=21600
ratelimit-remaining: 100;w=21600
docker-ratelimit-source: 50.92.13.38
```

authenticated

```
HTTP/1.1 200 OK
content-length: 2782
content-type: application/vnd.docker.distribution.manifest.v1+prettyjws
docker-content-digest: sha256:767a3815c34823b355bed31760d5fa3daca0aec2ce15b217c9cd83229e0e2020
docker-distribution-api-version: registry/2.0
etag: "sha256:767a3815c34823b355bed31760d5fa3daca0aec2ce15b217c9cd83229e0e2020"
date: Mon, 07 Feb 2022 21:57:35 GMT
strict-transport-security: max-age=31536000
docker-ratelimit-source: 3c5a9d6a-3ec6-4466-9e13-b112828125d3
```
